### PR TITLE
Slightly improve installation process

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -168,5 +168,9 @@ setup(
     ],
     ext_modules=ext_modules,
     cmdclass={"build_ext": BuildExtension} if ext_modules else {},
-    python_requires=">=3.7"
+    python_requires=">=3.7",
+    install_requires=[
+        "torch",
+        "einops",
+    ],
 )


### PR DESCRIPTION
Quick PR addressing two minor issues I encountered while installing `flash-attention`:

1. Adds the `einops` dependency to `setup.py` such that it's installed automatically along with the package.
2. Adds `__init__.py` to the `flash_attn` package such that `setup.py` properly detects it. Before, `flash_attn` could not be imported from outside of the `flash-attention` directory, even after the `setup.py` installation.