### PR TITLE
Make flash attention compile on Windows.

### DIFF
--- a/csrc/flash_attn/src/fmha_dgrad_fp16_kernel_loop.sm80.cu
+++ b/csrc/flash_attn/src/fmha_dgrad_fp16_kernel_loop.sm80.cu
@@ -2,6 +2,7 @@
  */
 
 #include "static_switch.h"
+#include "fp16_switch.h"
 #include "fmha.h"
 #include "fmha_dgrad_kernel_1xN_loop.h"
 
@@ -52,8 +53,8 @@ void run_fmha_dgrad_fp16_sm80_loop_(const FMHA_dgrad_params &params, cudaStream_
 }
 
 void run_fmha_dgrad_fp16_sm80(const FMHA_dgrad_params &params, cudaStream_t stream) {
-    BOOL_SWITCH(params.is_bf16, IsBf16Const, [&] {
-        using elem_type = std::conditional<IsBf16Const, __nv_bfloat16, __half>::type;
+    // work around for MSVC issue
+    FP16_SWITCH(params.is_bf16, [&] {
         auto dprops = at::cuda::getCurrentDeviceProperties();
         if (params.d == 16) {
             if( params.seqlen_k == 128 ) {

--- a/csrc/flash_attn/src/fmha_fprop_fp16_kernel.sm80.cu
+++ b/csrc/flash_attn/src/fmha_fprop_fp16_kernel.sm80.cu
@@ -29,6 +29,7 @@
 #include <cuda_bf16.h>
 
 #include "static_switch.h"
+#include "fp16_switch.h"
 #include "fmha.h"
 #include "fmha_fprop_kernel_1xN.h"
 
@@ -83,8 +84,7 @@ void run_fmha_fp16_sm80_loop_(Launch_params<FMHA_fprop_params> &launch_params,
 
 void run_fmha_fp16_sm80(Launch_params<FMHA_fprop_params> &launch_params,
                         const bool configure) {
-    BOOL_SWITCH(launch_params.params.is_bf16, IsBf16Const, [&] {
-        using elem_type = std::conditional<IsBf16Const, __nv_bfloat16, __half>::type;
+    FP16_SWITCH(launch_params.params.is_bf16, [&] {
         auto dprops = at::cuda::getCurrentDeviceProperties();
         if (launch_params.params.d == 16) {
             if( launch_params.params.seqlen_k == 128 ) {

--- a/csrc/flash_attn/src/fp16_switch.h
+++ b/csrc/flash_attn/src/fp16_switch.h
@@ -1,0 +1,27 @@
+// Inspired by https://github.com/NVIDIA/DALI/blob/main/include/dali/core/static_switch.h
+// and https://github.com/pytorch/pytorch/blob/master/aten/src/ATen/Dispatch.h
+
+// modified from static_switch.h 
+// because MSVC cannot handle std::conditional with constexpr variable
+
+#pragma once
+
+/// @param COND       - a boolean expression to switch by
+/// @param ...       - code to execute for true and false
+///
+/// Usage:
+/// ```
+/// FP16_SWITCH(flag, [&] {
+///     some_function(...);
+/// });
+/// ```
+#define FP16_SWITCH(COND, ...)                                           \
+    [&] {                                                                            \
+        if (COND) {                                                                  \
+            using elem_type = std::conditional<true, __nv_bfloat16, __half>::type;   \
+            return __VA_ARGS__();                                                    \
+        } else {                                                                     \
+            using elem_type = std::conditional<true, __nv_bfloat16, __half>::type;   \
+            return __VA_ARGS__();                                                    \
+        }                                                                            \
+    }()

--- a/csrc/flash_attn/src/fp16_switch.h
+++ b/csrc/flash_attn/src/fp16_switch.h
@@ -18,10 +18,10 @@
 #define FP16_SWITCH(COND, ...)                                           \
     [&] {                                                                            \
         if (COND) {                                                                  \
-            using elem_type = std::conditional<true, __nv_bfloat16, __half>::type;   \
+            using elem_type = __nv_bfloat16;   \
             return __VA_ARGS__();                                                    \
         } else {                                                                     \
-            using elem_type = std::conditional<true, __nv_bfloat16, __half>::type;   \
+            using elem_type = __half;   \
             return __VA_ARGS__();                                                    \
         }                                                                            \
     }()

--- a/setup.py
+++ b/setup.py
@@ -125,10 +125,11 @@ ext_modules.append(
             "csrc/flash_attn/src/fmha_block_dgrad_fp16_kernel_loop.sm80.cu",
         ],
         extra_compile_args={
-            "cxx": ["-O3"] + generator_flag,
+            "cxx": ["-O3", "-std=c++17"] + generator_flag,
             "nvcc": append_nvcc_threads(
                 [
                     "-O3",
+                    "-std=c++17",
                     "-U__CUDA_NO_HALF_OPERATORS__",
                     "-U__CUDA_NO_HALF_CONVERSIONS__",
                     "--expt-relaxed-constexpr",


### PR DESCRIPTION
This should resolve #50.

I was able to compile with CUDA 11.6, PyTorch 12.1 + CUDA 11.6, and an RTX 3090 as the target.

I haven't run any checks to see if the results are correct, is there any scripts for this purpose?

I was able to run the benchmark and saw big improvements in speed (~1/5 the time for forward + backward)
![Screenshot 2022-10-03 134837](https://user-images.githubusercontent.com/6364377/193644602-245ff1fa-fd46-4488-ab3a-04e37b5a31ce.jpg)


Hopefully someone else can also try to compile with this fork and see if it works for them.  Maybe @C43H66N12O12S2 would be interested in trying?

Also, huge thanks to @C43H66N12O12S2 to narrowing down the cause to "MSVC quirks with std::conditional" and C++17 being needed for the compiler, with that I was able to find the issue.

