### PR TITLE
build wheel and upload to release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,12 +5,9 @@
 name: Python Package
 
 on:
-  # create:
-  #   tags:
-  #     - '**'
-  push:
-    branch:
-      publish
+  create:
+    tags:
+      - '**'
 
 jobs:
   release:


### PR DESCRIPTION
Hi, @tridao , I notice that the recent [`GitHub actions`](https://github.com/HazyResearch/flash-attention/actions/runs/3260714185) failed due to the workflow can not get the release to upload the wheel. But in my forked repo, it's ok to [build the wheel and upload to the release](https://github.com/robotcator/flash-attention/actions/runs/3263863115), and the wheel can be seen on the [release page](https://github.com/robotcator/flash-attention/releases/tag/refs%2Fheads%2Fmain). 

It's a little bit wired, I change to `push trigger` on a certain branch to `tag create trigger` in this pr. The workflow works as follows, we create the tag for the recent commit, and then this action will trigger the GitHub action to build the wheel and upload the build wheel to release page, we can download the precompiled wheel rather than build from scratch.

