### PR TITLE
Change default dropout value in documentation

### DIFF
--- a/flash_attn/flash_attention.py
+++ b/flash_attn/flash_attention.py
@@ -16,7 +16,7 @@ class FlashAttention(nn.Module):
                       (default: 1/sqrt(d_keys) where d_keys is computed at
                       runtime)
         attention_dropout: The dropout rate to apply to the attention
-                           (default: 0.1)
+                           (default: 0.0)
     """
     def __init__(self, softmax_scale=None, attention_dropout=0.0, device=None, dtype=None):
         super().__init__()


### PR DESCRIPTION
Documentation says default is 0.1, but the code has attention_dropout default at 0.0