### PR TITLE
Remove unused kwargs like device in FlashAttention

### DIFF
--- a/flash_attn/flash_attention.py
+++ b/flash_attn/flash_attention.py
@@ -18,7 +18,7 @@ class FlashAttention(nn.Module):
         attention_dropout: The dropout rate to apply to the attention
                            (default: 0.0)
     """
-    def __init__(self, softmax_scale=None, attention_dropout=0.0, device=None, dtype=None):
+    def __init__(self, softmax_scale=None, attention_dropout=0.0):
         super().__init__()
         self.softmax_scale = softmax_scale
         self.dropout_p = attention_dropout
@@ -74,7 +74,7 @@ class FlashAttention(nn.Module):
 class FlashMHA(nn.Module):
 
     def __init__(self, embed_dim, num_heads, bias=True, batch_first=True, attention_dropout=0.0,
-                 causal=False, device=None, dtype=None, **kwargs) -> None:
+                 causal=False, device=None, dtype=None) -> None:
         assert batch_first
         factory_kwargs = {'device': device, 'dtype': dtype}
         super().__init__()
@@ -87,7 +87,7 @@ class FlashMHA(nn.Module):
         assert self.head_dim % 8 == 0 and self.head_dim <= 128, "Only support head_dim <= 128 and divisible by 8"
 
         self.Wqkv = nn.Linear(embed_dim, 3 * embed_dim, bias=bias, **factory_kwargs)
-        self.inner_attn = FlashAttention(attention_dropout=attention_dropout, **factory_kwargs)
+        self.inner_attn = FlashAttention(attention_dropout=attention_dropout)
         self.out_proj = nn.Linear(embed_dim, embed_dim, bias=bias, **factory_kwargs)
 
     def forward(self, x, key_padding_mask=None, need_weights=False):


### PR DESCRIPTION
I noticed that there were kwargs specified in the FlashAttention implementation to mirror PyTorch (device, dtype), but they weren't used.  This is a little confusing when you're first reading the code.

I can see an argument for leaving them in (to mirror PyTorch), but I can also see an argument for removing them, so they don't mislead users into thinking they do something.

I modified FlashMHA to not pass in the factory kwargs.  I removed the kwargs argument in this class as well, since it wasn't being used.

I'll leave it to you to decide if this makes sense or not.