### PR TITLE
Missing module in `setup.py`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -183,5 +183,6 @@ setup(
     install_requires=[
         "torch",
         "einops",
+        "packaging",
     ],
 )


### PR DESCRIPTION
Hi, have this message using pypi version


```
Collecting flash-attn
  Downloading flash_attn-1.0.1.tar.gz (1.9 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 1.9/1.9 MB 371.5 kB/s eta 0:00:00
  Preparing metadata (setup.py): started
  Preparing metadata (setup.py): finished with status 'error'
  error: subprocess-exited-with-error
  
  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [6 lines of output]
      Traceback (most recent call last):
        File "<string>", line 2, in <module>
        File "<pip-setuptools-caller>", line 34, in <module>
        File "/tmp/pip-install-n2wuvsgw/flash-attn_a2bf946cac174b0fab99cbff2ad5f6e6/setup.py", line 6, in <module>
          from packaging.version import parse, Version
      ModuleNotFoundError: No module named 'packaging'
      [end of output]
```