### PR TITLE
Use pyproject.toml to specify build dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ pip install flash-attn
 
 Alternatively you can compile from source:
 ```
-python setup.py install
+python -m pip install .
 ```
 
 Interface: `src/flash_attention.py`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["packaging", "setuptools", "torch", "wheel"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
This PR introduces a `pyproject.toml` file to list the build dependencies (see https://snarky.ca/what-the-heck-is-pyproject-toml/).

Before, the build dependencies were listed in `setup.py`, but in order to read this file, you would need to have those dependencies installed (packaging, torch). By adding a `pyproject.toml` file, python knows which packages are needed to build flash-attention.