### PR TITLE
[BugFix] avoid bug on ImportError

### DIFF
--- a/flash_attn/models/gpt.py
+++ b/flash_attn/models/gpt.py
@@ -46,7 +46,7 @@ except ImportError:
 try:
     from flash_attn.ops.rms_norm import RMSNorm, dropout_add_rms_norm
 except ImportError:
-    RMSNorm, dropout_add_rms_norm = None
+    RMSNorm, dropout_add_rms_norm = None, None
 
 try:
     from flash_attn.ops.rms_norm import dropout_add_rms_norm_parallel_residual

--- a/flash_attn/modules/block.py
+++ b/flash_attn/modules/block.py
@@ -26,7 +26,7 @@ except ImportError:
 try:
     from flash_attn.ops.rms_norm import RMSNorm, dropout_add_rms_norm
 except ImportError:
-    RMSNorm, dropout_add_rms_norm = None
+    RMSNorm, dropout_add_rms_norm = None, None
 
 try:
     from flash_attn.ops.rms_norm import dropout_add_rms_norm_parallel_residual


### PR DESCRIPTION
Simple fixes to avoid `cannot unpack non-iterable NoneType object` upon `ImportError` - bug found during a debugging session with @massastrello 