### PR TITLE
Fix compilation time

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["ninja", "packaging", "setuptools", "torch", "wheel"]
+requires = ["packaging", "setuptools", "torch", "wheel"]
 build-backend = "setuptools.build_meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["packaging", "setuptools", "wheel"]
+requires = ["ninja", "packaging", "setuptools", "wheel"]
 build-backend = "setuptools.build_meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["packaging", "setuptools", "torch", "wheel"]
+requires = ["packaging", "setuptools", "wheel"]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
There is a significant bump in compilation time going from `v1.0.4` &rarr; `v1.0.5`. It was ~2-3 minutes previously and now ranges from ~17-40 minutes. I did a bisect and narrowed it down to extra dependencies being required in the `pyproject.toml` file which are already set in the `install_requires` section during setup. I've left the `packaging` library as is in `[build-system]` since it's used by `setup.py` itself.