### PR TITLE
Metal FlashAttention

### DIFF
--- a/usage.md
+++ b/usage.md
@@ -124,4 +124,4 @@ yields the fastest BERT training on cloud instances in MLPerf training 2.0 (June
 - [Jax](https://github.com/google/jax): an [implementation](https://github.com/lucidrains/flash-attention-jax)
   in Jax by [lucidrains](https://github.com/lucidrains/).
 
-- [Metal](https://developer.apple.com/metal/): an [implementation](https://github.com/philipturner/metal-flash-attention) in Metal by Philip Turner. This ports FlashAttention to mobile GPU architectures such as Apple silicon.
+- [Metal](https://developer.apple.com/metal): an [implementation](https://github.com/philipturner/metal-flash-attention) in Metal by Philip Turner. This ports FlashAttention to mobile GPU architectures such as Apple silicon.

--- a/usage.md
+++ b/usage.md
@@ -123,3 +123,5 @@ yields the fastest BERT training on cloud instances in MLPerf training 2.0 (June
 
 - [Jax](https://github.com/google/jax): an [implementation](https://github.com/lucidrains/flash-attention-jax)
   in Jax by [lucidrains](https://github.com/lucidrains/).
+
+- [Metal](https://developer.apple.com/metal/): an [implementation](https://github.com/philipturner/metal-flash-attention) by Philip Turner. This ports FlashAttention to mobile GPU architectures such as Apple silicon.

--- a/usage.md
+++ b/usage.md
@@ -124,4 +124,4 @@ yields the fastest BERT training on cloud instances in MLPerf training 2.0 (June
 - [Jax](https://github.com/google/jax): an [implementation](https://github.com/lucidrains/flash-attention-jax)
   in Jax by [lucidrains](https://github.com/lucidrains/).
 
-- [Metal](https://developer.apple.com/metal/): an [implementation](https://github.com/philipturner/metal-flash-attention) by Philip Turner. This ports FlashAttention to mobile GPU architectures such as Apple silicon.
+- [Metal](https://developer.apple.com/metal/): an [implementation](https://github.com/philipturner/metal-flash-attention) in Metal by Philip Turner. This ports FlashAttention to mobile GPU architectures such as Apple silicon.


### PR DESCRIPTION
A [500-line implementation](https://github.com/philipturner/metal-flash-attention/blob/main/Sources/Attention.metal) of FlashAttention, and the first that does not require CUDA.

It has now passed an initial validation test (R=33, C=15, H=3, D=27, dense FP16), so it can be classified as a working FlashAttention implementation.

<details>
<summary>Head 0</summary>

<img width="998" alt="Screenshot_2023-07-14_at_3 15 14_PM" src="https://github.com/HazyResearch/flash-attention/assets/71743241/5e1a8ff8-d5c6-44d6-b6f8-d1db04d1207d">


</details>

<details>
<summary>Head 1</summary>

<img width="997" alt="Screenshot_2023-07-14_at_3 15 27_PM" src="https://github.com/HazyResearch/flash-attention/assets/71743241/40d95129-0f97-449f-8054-bd13ed9c4394">


</details>

<details>
<summary>Head 2</summary>

<img width="998" alt="Screenshot_2023-07-14_at_3 15 38_PM" src="https://github.com/HazyResearch/flash-attention/assets/71743241/67a47a1b-9f74-4727-b416-9e006c6027b9">


</details>

cc @liuliu